### PR TITLE
remove aml_nftl_dev module

### DIFF
--- a/config/boards/aml-s9xxx.conf
+++ b/config/boards/aml-s9xxx.conf
@@ -6,9 +6,6 @@ BOOTCONFIG_NEXT="kvim2_config"
 BOOTCONFIG_DEV="kvim2_config"
 BOARD_DIR=packages/bsp/aml-s9xxx
 #
-MODULES="aml_nftl_dev"
-MODULES_NEXT="aml_nftl_dev"
-#
 KERNEL_TARGET="default,next,dev"
 CLI_TARGET="stretch,xenial:default,next"
 DESKTOP_TARGET="xenial:default,next"


### PR DESCRIPTION
We no longer have aml_nftl_dev in mainline linux